### PR TITLE
Setup initial project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pkg/*
+*.gem
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,49 @@
+Metrics/LineLength:
+  # 80 just isn't enough
+  Max: 120
+
+Style/HashSyntax:
+  # Enforce `{ :key => :value }` over `{ key: :value }`
+  EnforcedStyle: hash_rockets
+
+Style/IfUnlessModifier:
+  # Allow single-line body if statements
+  #   if condition
+  #     do_something
+  #   end
+  Enabled: false
+
+Style/LineEndConcatenation:
+  # Allow concatenation with `+` and `<<`
+  # This was built to micro-optimize string concatenation by using `\`
+  #   since `+` and `<<` have a method call https://github.com/bbatsov/rubocop/issues/759
+  #   However, any decent compiler *should* optimize the concatenation away
+  Enabled: False
+
+Style/MethodCallParentheses:
+  # Allow usage of parens for argument-less invocations
+  #   App.new()
+  Enabled: false
+
+Style/RedundantReturn:
+  # Allow to explicitly state that a function should return
+  # e.g. `return 1` instead of `1`
+  Enabled: false
+
+Style/SpaceAroundEqualsInParameterDefault:
+  # Disable spaces around equal sign in default parameters
+  # e.g. `func(param=nil)` instead of `func(param = nil)`
+  EnforcedStyle: no_space
+
+Style/StringLiterals:
+  # Always use double quotes as we find it tedious to jump back/forth when adding/removing interpolation
+  EnforcedStyle: double_quotes
+
+Style/TrailingComma:
+  # Force trailing comma for multiline array definitions
+  EnforcedStyleForMultiline: comma
+
+Style/WordArray:
+  # Prefer normal string array `["string"]` over word arrays `%w(string)`
+  # DEV: This is to make Ruby more approachable for non-Ruby users
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+# Enable container infrastructure
+# http://docs.travis-ci.com/user/migrating-from-legacy/
+sudo: false
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in webmock-fixtures.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,22 @@
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
+
+task :default => :test
+
+desc "Run RSpec on the source"
+task :spec do
+  RSpec::Core::RakeTask.new(:spec)
+end
+
+desc "Run RuboCop on the source"
+task :lint do
+  RuboCop::RakeTask.new(:lint) do |task|
+    task.options = ["--config", ".rubocop.yml"]
+  end
+end
+
+desc "Run RSpec and RuboCop on the source"
+task :test do
+  Rake::Task[:lint].invoke
+  Rake::Task[:spec].invoke
+end

--- a/lib/webmock/fixtures.rb
+++ b/lib/webmock/fixtures.rb
@@ -1,0 +1,2 @@
+require "webmock"
+require "webmock/fixtures/manager"

--- a/lib/webmock/fixtures/manager.rb
+++ b/lib/webmock/fixtures/manager.rb
@@ -1,0 +1,8 @@
+module WebMock
+  # WebMock fixture helper
+  module Fixtures
+    # Class used to manage WebMock fixtures
+    class Manager
+    end
+  end
+end

--- a/lib/webmock/fixtures/version.rb
+++ b/lib/webmock/fixtures/version.rb
@@ -1,0 +1,6 @@
+module WebMock
+  # WebMock fixture helper
+  module Fixtures
+    VERSION = "0.1.0"
+  end
+end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -1,0 +1,9 @@
+require "webmock/fixtures"
+
+describe WebMock::Fixtures::Manager do
+  describe "constructor" do
+    it "should not fail" do
+      WebMock::Fixtures::Manager.new()
+    end
+  end
+end

--- a/webmock-fixtures.gemspec
+++ b/webmock-fixtures.gemspec
@@ -1,0 +1,26 @@
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+require "webmock/fixtures/version"
+
+Gem::Specification.new do |s|
+  # Gem information
+  s.name = "webmock-fixtures"
+  s.version = WebMock::Fixtures::VERSION
+  s.platform = Gem::Platform::RUBY
+  s.authors = ["Brett Langdon"]
+  s.email = ["me@brett.is"]
+  s.homepage = "http://github.com/underdogio/webmock-fixtures"
+  s.summary = "Manage WebMock fixtures"
+  s.description = "Library to help manage WebMock fixtures"
+  s.license = "MIT"
+
+  # Dependencies
+  s.add_runtime_dependency("webmock", [">= 1.0.0", "< 2.0.0"])
+  s.add_development_dependency("rake", [">= 10.0.0", "< 11.0.0"])
+  s.add_development_dependency("rspec", [">= 3.3.0", "< 3.4.0"])
+  s.add_development_dependency("rubocop", [">= 0.34.0", "< 0.35.0"])
+
+  # Files
+  s.files = `git ls-files`.split("\n")
+  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.require_paths = ["lib"]
+end


### PR DESCRIPTION
This first PR is just to setup the basic skeleton of the gem. I wanted to keep this PR separate from the actual code of the gem so we can focus on the gem structure here. I mostly used https://github.com/dburkes/webmock-disabler and https://github.com/bblimke/webmockas references here.

Contained here:
- Add `gemspec` file
- Add skeleton `lib` and `spec` directories
- Setup `RuboCop` and `RSpec` with `rake`
- Setup `travis-ci`

/cc @twolfson 
