### PR TITLE
First version of library

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@ Metrics/LineLength:
   # 80 just isn't enough
   Max: 120
 
+Metrics/MethodLength:
+  # This gets noisy for scripts and we don't need it yet
+  Enabled: false
+
 Style/HashSyntax:
   # Enforce `{ :key => :value }` over `{ key: :value }`
   EnforcedStyle: hash_rockets
@@ -29,6 +33,11 @@ Style/RedundantReturn:
   # Allow to explicitly state that a function should return
   # e.g. `return 1` instead of `1`
   Enabled: false
+
+Style/RegexpLiteral:
+  # Always use %r{...} around regular expressions
+  # e.g. `%r{pattern}` instead of `/pattern/`
+  EnforcedStyle: percent_r
 
 Style/SpaceAroundEqualsInParameterDefault:
   # Disable spaces around equal sign in default parameters

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ rvm:
   - 2.1
   - 2.2
   - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -4,13 +4,74 @@ Library for managing [WebMock][] fixtures.
 
 [WebMock]: https://github.com/bblimke/webmock
 
-## Installation
+[Documentation](http://www.rubydoc.info/github/underdogio/webmock-fixtures).
 
+## Installation
 `gem install webmock-fixtures`
 
 or with Bundler
 
-`gem 'webmock-fixtures`
+`gem "webmock-fixtures"`
+
+## Getting Started
+WebMock fixtures provides a way to pre-define all of your fixtures ahead of time and start them easily during tests.
+
+```ruby
+require "rspec"
+require "webmock/fixtures"
+require "webmock/rspec"
+
+# Register our fixture for www.example.org
+WebMock::Fixtures::Manager.register_fixture(
+  :get_example, :get, %r{www.example.org}, :body => "Hello World")
+
+RSpec.describe do
+  describe "a web request to www.example.org" do
+    # Start the registered fixtures
+    # DEV: `WebMock` will auto-reset after each test:
+    #   https://github.com/bblimke/webmock/blob/v1.22.3/lib/webmock/rspec.rb#L23-L31
+    let!(:manager) { WebMock::Fixtures::Manager.run([:get_example]) }
+
+    it "should respond with the fixture body" do
+      # Assert that an HTTP request gets the expected response
+      response = Net::HTTP.get("www.example.org", "/")
+      expect(response).to(eq("Hello World"))
+
+      # Assert that our stub was called
+      # DEV: `stub` is the created `WebMock::RequestStub` for the started fixture
+      stub = manager[:get_example]
+      expect(stub).to(have_been_requested.once)
+    end
+  end
+end
+```
+
+As well, by subclassing `WebMock::Fixtures::Manager` you can easily separate and organize your test fixtures. For example:
+
+```ruby
+# Manager to store fixtures associated with Google
+class GoogleManager < WebMock::Fixtures::Manager
+  # Define fixtures in class definition
+  @fixtures = {
+    :get_homepage => {
+      :verb => :get,
+      :pattern => %r{www.google.com},
+      :response => {
+        :body => "Google",
+      },
+    },
+  }
+end
+
+# Manager to store fixtures associated with Elasticsearch
+class ElasticsearchManager < WebMock::Fixtures::Manager
+end
+ElasticsearchManager.register_fixture_file(
+  :search_people, :get, %r{localhost:9002/people/person/_search}, "/path/to/file.raw")
+
+google_manager = GoogleManager.run([:get_homepage])
+elasticsearch_manager = ElasticsearchManager.run([:search_people])
+```
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.

--- a/examples/getting_started_spec.rb
+++ b/examples/getting_started_spec.rb
@@ -1,0 +1,27 @@
+require "rspec"
+require "webmock/fixtures"
+require "webmock/rspec"
+
+# Register our fixture for www.example.org
+WebMock::Fixtures::Manager.register_fixture(
+  :get_example, :get, %r{www.example.org}, :body => "Hello World")
+
+RSpec.describe do
+  describe "a web request to www.example.org" do
+    # Start the registered fixtures
+    # DEV: `WebMock` will auto-reset after each test:
+    #   https://github.com/bblimke/webmock/blob/v1.22.3/lib/webmock/rspec.rb#L23-L31
+    let!(:manager) { WebMock::Fixtures::Manager.run([:get_example]) }
+
+    it "should respond with the fixture body" do
+      # Assert that an HTTP request gets the expected response
+      response = Net::HTTP.get("www.example.org", "/")
+      expect(response).to(eq("Hello World"))
+
+      # Assert that our stub was called
+      # DEV: `stub` is the created `WebMock::RequestStub` for the started fixture
+      stub = manager[:get_example]
+      expect(stub).to(have_been_requested.once)
+    end
+  end
+end

--- a/lib/webmock/fixtures/manager.rb
+++ b/lib/webmock/fixtures/manager.rb
@@ -3,6 +3,108 @@ module WebMock
   module Fixtures
     # Class used to manage WebMock fixtures
     class Manager
+      # Available fixtures which have been loaded
+      @fixtures = {}
+
+      # Fetch the started `WebMock::RequestStub`s that belong to this manager
+      # @return [Hash] a Hash of fixture names mapped to their started `WebMock::RequestStub`
+      attr_reader :started_fixtures
+
+      # Constructor for Manager
+      def initialize
+        # We will use `@started_fixtures` to store our started fixtures
+        @started_fixtures = {}
+      end
+
+      # Fetch the `WebMock::RequestStub` for any started fixtures
+      # @param fixture_name [Symbol] the symbol name of the fixture
+      # @return [WebMock::RequestStub] the started fixture stub
+      # @raise [KeyError] if the fixture requested has not been started
+      def [](fixture_name)
+        # DEV: `fetch` wil raise `KeyError` if `fixture_name` does not exist
+        return @started_fixtures.fetch(fixture_name)
+      end
+
+      # Store an instance of `WebMock::RequestStub` for a given fixture
+      # @param fixture_name [Symbol] the symbol name of the fixture started
+      # @param stub [WebMock::RequestStub] the stub that was started for the fixture
+      def []=(fixture_name, stub)
+        @started_fixtures[fixture_name] = stub
+      end
+
+      # Ensure every subclass of `Manager` sets `@fixtures` to `{}` (by default it will be `nil`)
+      # @classmethod
+      # @param subclass [Class] the class instance which is subclassing `Manager`
+      def self.inherited(subclass)
+        subclass.instance_variable_set(:@fixtures, {})
+      end
+
+      # Preload a web fixture which can then be started via `Manager.run`
+      # @classmethod
+      # @param name [Symbol] the name to register the fixture as
+      # @param verb [Symbol] symbol method to mock (e.g. `:get`, `:post`)
+      # @param pattern [Regexp|String] URI pattern to match for this mock
+      # @param response [String|File|Lambda|Hash] the response, this is the same as what would be supplied
+      #   to `WebMock::RequestStub#to_return` please see https://github.com/bblimke/webmock for examples
+      def self.register_fixture(name, verb, pattern, response)
+        @fixtures[name] = {
+          :pattern => pattern,
+          :verb => verb,
+          :response => response,
+        }
+      end
+
+      # Retrieve a hash of registered fixtures available to this Manager
+      # @classmethod
+      # @return [Hash] a hash mapping the registered name to a hash of properties
+      #   e.g. `{ :get_example => { :pattern => %r{example.org}, :verb => :get, :response => "Hello World" } }`
+      def self.fixtures
+        return @fixtures
+      end
+
+      # Reset this manager by removing all previously registered fixtures
+      # @classmethod
+      def self.reset!
+        @fixtures = {}
+      end
+
+      # Preload a web fixture from a file which can then be started via `Manager.run`
+      # @classmethod
+      # @param name [Symbol] the name to register the fixture as
+      # @param verb [Symbol] symbol method to mock (e.g. `:get`, `:post`)
+      # @param pattern [Regexp|String] URI pattern to match for this mock
+      # @param file_name [String] the name of the file to load the fixture response from
+      def self.register_fixture_file(name, verb, pattern, file_name)
+        # Read the contents from the file and use as the response
+        # https://github.com/bblimke/webmock/tree/v1.22.1#replaying-raw-responses-recorded-with-curl--is
+        register_fixture(name, verb, pattern, File.new(file_name).read)
+      end
+
+      # Start the named preloaded web fixtures
+      # @classmethod
+      # @param fixture_names [Array] the symbol names of fixtures to load and start
+      # @return [Manager] an instance of Manager which has properties set for each started fixture
+      # @raise [KeyError] if the fixture has not been preloaded via `::register_fixture` or `::register_fixture_file`
+      def self.run(fixture_names)
+        # Create a new instance to store started mocks on
+        manager = new()
+        fixture_names.each do |fixture_name|
+          # DEV: `fetch` will fail if the key does not exist
+          unless @fixtures.key?(fixture_name)
+            fail(KeyError, "The fixture \"#{fixture_name}\" was not found. Please make sure to " +
+                           "register it with ::register_fixture or ::register_fixture_file")
+          end
+
+          # Create the WebMock stub
+          fixture_options = @fixtures[fixture_name]
+          stub = WebMock::API.stub_request(fixture_options[:verb], fixture_options[:pattern])
+          stub.to_return(fixture_options[:response])
+
+          # Store the started stub on the manager instance
+          manager[fixture_name] = stub
+        end
+        return manager
+      end
     end
   end
 end

--- a/spec/get_httpbin_200.raw
+++ b/spec/get_httpbin_200.raw
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 09 Nov 2015 21:14:59 GMT
+Content-Type: application/json
+Content-Length: 211
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Credentials: true
+
+{
+  "args": {
+    "page": "1"
+  }, 
+  "headers": {
+    "Accept": "*/*", 
+    "Host": "httpbin.org", 
+    "User-Agent": "curl/7.43.0"
+  }, 
+  "origin": "69.12.27.190", 
+  "url": "http://httpbin.org/get?page=1"
+}

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -1,9 +1,180 @@
 require "webmock/fixtures"
+require "webmock/rspec"
 
 describe WebMock::Fixtures::Manager do
-  describe "constructor" do
-    it "should not fail" do
-      WebMock::Fixtures::Manager.new()
+  after(:example) do
+    # Ensure we remove any added fixtures between tests
+    WebMock::Fixtures::Manager.reset!
+  end
+
+  before(:example) do
+    # Register a single fixture before each test
+    WebMock::Fixtures::Manager.register_fixture(:get_example, :get, %r{www.example.org}, :body => "Hello World")
+  end
+
+  describe "::reset!" do
+    it "should remove any registered fixtures" do
+      expect(WebMock::Fixtures::Manager.fixtures[:get_example]).to_not(be_nil)
+      WebMock::Fixtures::Manager.reset!
+      expect(WebMock::Fixtures::Manager.fixtures).to(eq({}))
+    end
+  end
+
+  describe "::register_fixture" do
+    context "with a subclassed manager" do
+      it "should not share registered fixtures" do
+        class TestManager < WebMock::Fixtures::Manager
+          @fixtures = {
+            :get_google => {
+              :verb => :get,
+              :pattern => %r{www.google.com},
+              :response => {
+                :body => "Google",
+              },
+            },
+          }
+        end
+
+        # Ensure TestManager has the appropriate fixtures
+        expect(TestManager.fixtures.keys()).to(eq([:get_google]))
+        expect(TestManager.fixtures[:get_google]).to_not(be_nil)
+
+        # Ensure WebMock::Fixtures::Manager has the appropriate fixtures
+        expect(WebMock::Fixtures::Manager.fixtures.keys()).to(eq([:get_example]))
+        expect(WebMock::Fixtures::Manager.fixtures[:get_google]).to(be_nil)
+      end
+    end
+
+    it "should properly register the fixture" do
+      expected = {
+        :pattern => %r{www.example.org},
+        :verb => :get,
+        :response => {
+          :body => "Hello World",
+        },
+      }
+      expect(WebMock::Fixtures::Manager.fixtures[:get_example]).to(eq(expected))
+    end
+
+    it "should properly respond to a web request" do
+      # Start our fixtures
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+
+      # Assert http call responds with our fixture
+      response = Net::HTTP.get("www.example.org", "/")
+      expect(response).to(eq("Hello World"))
+
+      # Assert our stub was requested
+      stub = manager[:get_example]
+      expect(stub).to(have_been_requested.once)
+    end
+  end
+
+  describe "::register_fixture_file" do
+    before(:example) do
+      fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "get_httpbin_200.raw")
+      WebMock::Fixtures::Manager.register_fixture_file(
+        :get_httpbin, :get, %r{^http://httpbin\.org/get\?page=1$}, fixture_path)
+    end
+
+    it "should properly register a fixture" do
+      fixture = WebMock::Fixtures::Manager.fixtures[:get_httpbin]
+      expect(fixture[:verb]).to(eq(:get))
+      expect(fixture[:pattern]).to(eq(%r{^http://httpbin\.org/get\?page=1$}))
+
+      # Assert that we loaded the raw HTTP request from the file as a string
+      expect(fixture[:response]).to(be_a(String))
+      # Assert we have response headers
+      expect(fixture[:response]).to(match(%r{Content-Type: application/json}))
+      # Assert we have part of the response body
+      expect(fixture[:response]).to(match(%r{"url": "http://httpbin\.org/get\?page=1"}))
+    end
+
+    it "should properly respond to a web request" do
+      # Start our fixtures
+      manager = WebMock::Fixtures::Manager.run([:get_httpbin])
+
+      # Assert http call responds with our fixture
+      response = Net::HTTP.get(URI("http://httpbin.org/get?page=1"))
+      response = JSON.load(response)
+      expect(response["url"]).to(eq("http://httpbin.org/get?page=1"))
+
+      # Assert that our stub was requested
+      stub = manager[:get_httpbin]
+      expect(stub).to(have_been_requested.once)
+    end
+  end
+
+  describe "::run" do
+    context "with an unknown fixture name" do
+      it "should raise an error" do
+        expect { WebMock::Fixtures::Manager.run([:unknown_fixture]) } .to(raise_error(KeyError))
+      end
+    end
+
+    context "with multiple instances" do
+      before(:example) do
+        # Register an additional fixture to use during these tests
+        WebMock::Fixtures::Manager.register_fixture(:get_google, :get, %r{www.google.com}, :body => "Google")
+      end
+
+      it "should not share started fixtures" do
+        google_manager = WebMock::Fixtures::Manager.run([:get_google])
+        example_manager = WebMock::Fixtures::Manager.run([:get_example])
+
+        expect(google_manager.started_fixtures.keys()).to(eq([:get_google]))
+        expect(example_manager.started_fixtures.keys()).to(eq([:get_example]))
+      end
+    end
+
+    it "should return a manager" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      expect(manager).to(be_a(WebMock::Fixtures::Manager))
+    end
+
+    it "should start the requested request stub" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      expect(manager.started_fixtures.keys()).to(eq([:get_example]))
+      expect(manager.started_fixtures[:get_example]).to(be_a(WebMock::RequestStub))
+    end
+  end
+
+  describe "::new" do
+    it "should not start any fixtures" do
+      manager = WebMock::Fixtures::Manager.new()
+      expect(manager.started_fixtures).to(eq({}))
+    end
+  end
+
+  describe "#[]" do
+    it "should retreive a started fixture" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      expect(manager[:get_example]).to(be_a(WebMock::RequestStub))
+    end
+
+    it "should raise an error with an unknown fixture" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      expect { manager[:unknown_example] }.to(raise_error(KeyError))
+    end
+  end
+
+  describe "#[]=" do
+    it "should assign over a known fixture" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      manager[:get_example] = "Test"
+      expect(manager[:get_example]).to(eq("Test"))
+    end
+
+    it "should assign a new fixture" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      manager[:unknown_example] = "Test"
+      expect(manager[:unknown_example]).to(eq("Test"))
+    end
+
+    it "should not effect existing fixtures" do
+      manager = WebMock::Fixtures::Manager.run([:get_example])
+      manager[:unknown_example] = "Test"
+      expect(manager[:get_example]).to(be_a(WebMock::RequestStub))
     end
   end
 end


### PR DESCRIPTION
Finally finished the initial version of the library.

There are a few additions here than what we originally had planned, mostly added to aid in writing tests.
- `Manager::reset!` - resets the internal `@registered_fixtures` property
- `Manager::registered_fixtures` - reader to access `@registered_fixtures`
- `Manager#started_fixtures` - reader to access the internal `@started_fixtures` property

Included in this PR:
- Initial code for `WebMock::Fixtures::Manager`
- Tests for `WebMock::Fixtures::Manager`
- Updated `README.md` docs

It appears that we will get some docs for free from http://www.rubydoc.info/. We can view them now as http://www.rubydoc.info/github/underdogio/webmock-fixtures, but only for the master branch it seems, once we publish this gem we can change to http://www.rubydoc.info/gems/webmock-fixtures.

/cc @twolfson 
