### PR TITLE
Update documentation url and add badges to README

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown - LICENSE-MIT CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 WebMock fixtures
 ================
+[![Gem Version](https://badge.fury.io/rb/webmock-fixtures.svg)](https://rubygems.org/gems/webmock-fixtures)
+[![Build Status](https://travis-ci.org/underdogio/webmock-fixtures.svg?branch=master)](https://travis-ci.org/underdogio/webmock-fixtures)
+
 Library for managing [WebMock][] fixtures.
 
 [WebMock]: https://github.com/bblimke/webmock
 
-[Documentation](http://www.rubydoc.info/github/underdogio/webmock-fixtures).
+[Documentation](http://www.rubydoc.info/gems/webmock-fixtures).
 
 ## Installation
 `gem install webmock-fixtures`

--- a/lib/webmock/fixtures/manager.rb
+++ b/lib/webmock/fixtures/manager.rb
@@ -46,6 +46,7 @@ module WebMock
       # @param pattern [Regexp|String] URI pattern to match for this mock
       # @param response [String|File|Lambda|Hash] the response, this is the same as what would be supplied
       #   to `WebMock::RequestStub#to_return` please see https://github.com/bblimke/webmock for examples
+      # @return [nil]
       def self.register_fixture(name, verb, pattern, response)
         @fixtures[name] = {
           :pattern => pattern,
@@ -57,6 +58,7 @@ module WebMock
       # Retrieve a hash of registered fixtures available to this Manager
       # @classmethod
       # @return [Hash] a hash mapping the registered name to a hash of properties
+      #
       #   e.g. `{ :get_example => { :pattern => %r{example.org}, :verb => :get, :response => "Hello World" } }`
       def self.fixtures
         return @fixtures
@@ -64,6 +66,7 @@ module WebMock
 
       # Reset this manager by removing all previously registered fixtures
       # @classmethod
+      # @return [nil]
       def self.reset!
         @fixtures = {}
       end


### PR DESCRIPTION
Now that `webmock-fixtures` is published to RubyGems we can update the documentation link to point to http://www.rubydoc.info/gems/webmock-fixtures

As well, I added in ruby gem version badge and travis build status badges to the README.

Fixes #5 

/cc @twolfson 
